### PR TITLE
Add Compose login flow with animated splash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.animation)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/countrydelight/testproject/MainActivity.kt
+++ b/app/src/main/java/com/countrydelight/testproject/MainActivity.kt
@@ -5,12 +5,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import com.countrydelight.testproject.ui.login.LoginFlow
 import com.countrydelight.testproject.ui.theme.TestProjectTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,29 +16,10 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             TestProjectTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    LoginFlow()
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    TestProjectTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/countrydelight/testproject/ui/login/LoginScreens.kt
+++ b/app/src/main/java/com/countrydelight/testproject/ui/login/LoginScreens.kt
@@ -1,0 +1,82 @@
+package com.countrydelight.testproject.ui.login
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.Image
+import com.countrydelight.testproject.R
+import kotlinx.coroutines.delay
+
+@Composable
+fun LoginFlow() {
+    var showInput by remember { mutableStateOf(false) }
+    val logoOffset by animateDpAsState(
+        targetValue = if (showInput) (-200).dp else 0.dp,
+        animationSpec = tween(durationMillis = 600)
+    )
+    LaunchedEffect(Unit) {
+        delay(1000)
+        showInput = true
+    }
+    Box(modifier = Modifier.fillMaxSize()) {
+        Image(
+            painter = painterResource(id = R.mipmap.ic_launcher),
+            contentDescription = "Logo",
+            modifier = Modifier
+                .size(120.dp)
+                .align(Alignment.Center)
+                .offset(y = logoOffset)
+        )
+        AnimatedVisibility(
+            visible = showInput,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        ) {
+            MobileInputBox()
+        }
+    }
+}
+
+@Composable
+fun MobileInputBox() {
+    var number by remember { mutableStateOf("") }
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        OutlinedTextField(
+            value = number,
+            onValueChange = { input ->
+                val digits = input.filter { it.isDigit() }
+                if (digits.length <= 10) number = digits
+            },
+            label = { Text("Mobile Number") },
+            leadingIcon = { Text("+91") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(
+            onClick = {},
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Submit")
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row {
+            Text("Privacy Policy")
+            Text(" | ")
+            Text("Terms & Conditions")
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-animation = { group = "androidx.compose.animation", name = "animation" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add compose animation dependency
- animate logo from splash to login form
- include phone input and policy links at the bottom
- update main activity to host new flow

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68492eb0ce8c83238c151bb2d0361c1b